### PR TITLE
feat: Card component with delete and relative dates

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,42 @@
+import type { Card as CardType } from '../types';
+import { formatRelativeDate } from '../utils/formatRelativeDate';
+
+interface CardProps {
+  card: CardType;
+  onDelete: (cardId: string) => void;
+}
+
+export function Card({ card, onDelete }: CardProps) {
+  return (
+    <article className="group relative bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow p-3">
+      <button
+        onClick={() => onDelete(card.id)}
+        aria-label={`Delete ${card.title}`}
+        className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-400 hover:text-red-500 transition-opacity rounded p-0.5"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="w-4 h-4"
+          aria-hidden="true"
+        >
+          <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+        </svg>
+      </button>
+
+      <h3 className="font-bold text-sm text-gray-900 truncate pr-6">{card.title}</h3>
+
+      {card.description && (
+        <p className="mt-1 text-xs text-gray-600 line-clamp-2">{card.description}</p>
+      )}
+
+      <time
+        dateTime={card.createdAt}
+        className="mt-2 block text-xs text-gray-400"
+      >
+        {formatRelativeDate(card.createdAt)}
+      </time>
+    </article>
+  );
+}

--- a/src/components/__tests__/Card.test.tsx
+++ b/src/components/__tests__/Card.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { Card } from '../Card';
+import type { Card as CardType } from '../../types';
+
+const makeCard = (overrides: Partial<CardType> = {}): CardType => ({
+  id: 'card-1',
+  title: 'Test Card',
+  description: 'A test description',
+  columnId: 'todo',
+  position: 0,
+  createdAt: new Date().toISOString(),
+  ...overrides,
+});
+
+describe('Card', () => {
+  it('renders title, description, and creation date', () => {
+    render(<Card card={makeCard()} onDelete={vi.fn()} />);
+
+    expect(screen.getByText('Test Card')).toBeInTheDocument();
+    expect(screen.getByText('A test description')).toBeInTheDocument();
+    expect(screen.getByText('just now')).toBeInTheDocument();
+  });
+
+  it('renders as an article element', () => {
+    render(<Card card={makeCard()} onDelete={vi.fn()} />);
+    expect(screen.getByRole('article')).toBeInTheDocument();
+  });
+
+  it('renders delete button with accessible label', () => {
+    render(<Card card={makeCard({ title: 'My Task' })} onDelete={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Delete My Task' })).toBeInTheDocument();
+  });
+
+  it('calls onDelete with card id when delete button is clicked', async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    render(<Card card={makeCard({ id: 'abc-123' })} onDelete={onDelete} />);
+
+    await user.click(screen.getByRole('button', { name: 'Delete Test Card' }));
+    expect(onDelete).toHaveBeenCalledWith('abc-123');
+  });
+
+  it('truncates long titles with ellipsis via CSS class', () => {
+    render(<Card card={makeCard()} onDelete={vi.fn()} />);
+    const title = screen.getByText('Test Card');
+    expect(title.className).toContain('truncate');
+  });
+
+  it('truncates long descriptions to 2 lines via CSS class', () => {
+    render(<Card card={makeCard()} onDelete={vi.fn()} />);
+    const desc = screen.getByText('A test description');
+    expect(desc.className).toContain('line-clamp-2');
+  });
+
+  it('does not render description paragraph when description is empty', () => {
+    render(<Card card={makeCard({ description: '' })} onDelete={vi.fn()} />);
+    expect(screen.queryByText('A test description')).not.toBeInTheDocument();
+    const article = screen.getByRole('article');
+    expect(article.querySelectorAll('p')).toHaveLength(0);
+  });
+
+  it('renders a time element with datetime attribute', () => {
+    const createdAt = '2026-01-15T12:00:00Z';
+    render(<Card card={makeCard({ createdAt })} onDelete={vi.fn()} />);
+    const timeEl = screen.getByText(/ago|just now|2026/);
+    expect(timeEl.tagName).toBe('TIME');
+    expect(timeEl).toHaveAttribute('datetime', createdAt);
+  });
+});

--- a/src/utils/__tests__/formatRelativeDate.test.ts
+++ b/src/utils/__tests__/formatRelativeDate.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { formatRelativeDate } from '../formatRelativeDate';
+
+describe('formatRelativeDate', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "just now" for dates less than a minute ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T12:00:30Z'));
+    expect(formatRelativeDate('2026-01-15T12:00:00Z')).toBe('just now');
+  });
+
+  it('returns minutes ago for dates less than an hour ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T12:05:00Z'));
+    expect(formatRelativeDate('2026-01-15T12:00:00Z')).toBe('5m ago');
+  });
+
+  it('returns hours ago for dates less than a day ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T15:00:00Z'));
+    expect(formatRelativeDate('2026-01-15T12:00:00Z')).toBe('3h ago');
+  });
+
+  it('returns days ago for dates less than 30 days ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-20T12:00:00Z'));
+    expect(formatRelativeDate('2026-01-15T12:00:00Z')).toBe('5d ago');
+  });
+
+  it('returns formatted date for dates older than 30 days', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-15T12:00:00Z'));
+    const result = formatRelativeDate('2026-01-15T12:00:00Z');
+    expect(result).toMatch(/1\/15\/2026|15\/1\/2026|2026/);
+  });
+});

--- a/src/utils/formatRelativeDate.ts
+++ b/src/utils/formatRelativeDate.ts
@@ -1,0 +1,16 @@
+export function formatRelativeDate(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSeconds < 60) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 30) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString();
+}


### PR DESCRIPTION
## Summary
- Created `Card.tsx` component displaying title (bold, truncated), description (2-line clamp), and relative creation date
- Styled with Tailwind: white background, rounded corners, subtle shadow, hover elevation effect
- Delete button (X icon) in top-right corner, visible on hover and focus
- Accessible: semantic `<article>` element, keyboard-navigable delete button with `aria-label`, `<time>` element with `datetime` attribute
- Added `formatRelativeDate` utility for human-readable relative timestamps
- Comprehensive unit tests for both the component and the utility

Closes #5

## Test plan
- [x] All 29 tests pass (`npm test`)
- [x] TypeScript compiles without errors
- [ ] Visual QA: verify card renders correctly in a column
- [ ] Verify hover states (shadow elevation, delete button visibility)
- [ ] Verify delete button calls onDelete with correct card ID
- [ ] Verify truncation of long titles and descriptions