### PR TITLE
feat: add Board layout with 5 columns

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -10,17 +10,12 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the tech stack description", () => {
+  it("renders all 5 columns", () => {
     render(<App />);
-    expect(
-      screen.getByText("Vite + React + TypeScript + Tailwind CSS")
-    ).toBeInTheDocument();
-  });
-
-  it("applies Tailwind utility classes", () => {
-    render(<App />);
-    const heading = screen.getByText("Trello-Style TODO Board");
-    expect(heading.className).toContain("text-4xl");
-    expect(heading.className).toContain("font-bold");
+    expect(screen.getByText("Backlog")).toBeInTheDocument();
+    expect(screen.getByText("To Do")).toBeInTheDocument();
+    expect(screen.getByText("In Progress")).toBeInTheDocument();
+    expect(screen.getByText("Review")).toBeInTheDocument();
+    expect(screen.getByText("Done")).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,19 @@
+import { Board } from './components/Board';
+import { useBoardState } from './hooks/useBoardState';
+
 function App() {
+  const { getColumnCards } = useBoardState();
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold text-gray-900 mb-4">
+    <div className="h-screen flex flex-col bg-gray-50">
+      <header className="flex items-center px-4 py-3 bg-white border-b border-gray-200">
+        <h1 className="text-lg font-bold text-gray-900">
           Trello-Style TODO Board
         </h1>
-        <p className="text-lg text-gray-600">
-          Vite + React + TypeScript + Tailwind CSS
-        </p>
-      </div>
+      </header>
+      <main className="flex-1 overflow-hidden">
+        <Board getColumnCards={getColumnCards} />
+      </main>
     </div>
   );
 }

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,0 +1,18 @@
+import { COLUMNS } from '../constants/columns';
+import type { Card } from '../types';
+import type { ColumnId } from '../types';
+import { Column } from './Column';
+
+interface BoardProps {
+  getColumnCards: (columnId: ColumnId) => Card[];
+}
+
+export function Board({ getColumnCards }: BoardProps) {
+  return (
+    <div className="flex gap-4 h-full p-4">
+      {COLUMNS.map((col) => (
+        <Column key={col.id} title={col.title} cards={getColumnCards(col.id)} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -1,0 +1,33 @@
+import type { Card } from '../types';
+
+interface ColumnProps {
+  title: string;
+  cards: Card[];
+}
+
+export function Column({ title, cards }: ColumnProps) {
+  return (
+    <div className="flex flex-col flex-1 min-w-0 bg-gray-100 rounded-lg">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200">
+        <h2 className="text-sm font-semibold text-gray-700 truncate">{title}</h2>
+        <span className="ml-2 inline-flex items-center justify-center px-2 py-0.5 text-xs font-medium text-gray-600 bg-gray-200 rounded-full">
+          {cards.length}
+        </span>
+      </div>
+      <div className="flex-1 overflow-y-auto p-2 space-y-2">
+        {cards.length === 0 ? (
+          <p className="text-sm text-gray-400 text-center py-4">No cards</p>
+        ) : (
+          cards.map((card) => (
+            <div
+              key={card.id}
+              className="bg-white rounded shadow-sm p-3 text-sm text-gray-800"
+            >
+              {card.title}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Board } from "../Board";
+import type { Card, ColumnId } from "../../types";
+
+describe("Board", () => {
+  const emptyGetColumnCards = () => [] as Card[];
+
+  it("renders all 5 column titles", () => {
+    render(<Board getColumnCards={emptyGetColumnCards} />);
+    expect(screen.getByText("Backlog")).toBeInTheDocument();
+    expect(screen.getByText("To Do")).toBeInTheDocument();
+    expect(screen.getByText("In Progress")).toBeInTheDocument();
+    expect(screen.getByText("Review")).toBeInTheDocument();
+    expect(screen.getByText("Done")).toBeInTheDocument();
+  });
+
+  it("renders columns in a flex row", () => {
+    const { container } = render(<Board getColumnCards={emptyGetColumnCards} />);
+    const boardEl = container.firstElementChild!;
+    expect(boardEl.className).toContain("flex");
+  });
+
+  it("passes cards from getColumnCards to each column", () => {
+    const mockCards: Record<ColumnId, Card[]> = {
+      backlog: [
+        {
+          id: "1",
+          title: "Backlog task",
+          description: "",
+          columnId: "backlog",
+          position: 0,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      todo: [],
+      "in-progress": [],
+      review: [],
+      done: [],
+    };
+
+    render(
+      <Board getColumnCards={(colId: ColumnId) => mockCards[colId]} />
+    );
+    expect(screen.getByText("Backlog task")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("shows empty state in columns with no cards", () => {
+    render(<Board getColumnCards={emptyGetColumnCards} />);
+    const emptyMessages = screen.getAllByText("No cards");
+    expect(emptyMessages).toHaveLength(5);
+  });
+});

--- a/src/components/__tests__/Column.test.tsx
+++ b/src/components/__tests__/Column.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Column } from "../Column";
+import type { Card } from "../../types";
+
+const makeCard = (overrides: Partial<Card> = {}): Card => ({
+  id: crypto.randomUUID(),
+  title: "Test card",
+  description: "",
+  columnId: "backlog",
+  position: 0,
+  createdAt: new Date().toISOString(),
+  ...overrides,
+});
+
+describe("Column", () => {
+  it("renders the column title", () => {
+    render(<Column title="Backlog" cards={[]} />);
+    expect(screen.getByText("Backlog")).toBeInTheDocument();
+  });
+
+  it("shows card count badge", () => {
+    const cards = [makeCard(), makeCard()];
+    render(<Column title="Backlog" cards={cards} />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("shows zero count when empty", () => {
+    render(<Column title="Backlog" cards={[]} />);
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  it("renders empty state message when no cards", () => {
+    render(<Column title="Backlog" cards={[]} />);
+    expect(screen.getByText("No cards")).toBeInTheDocument();
+  });
+
+  it("renders card titles", () => {
+    const cards = [
+      makeCard({ title: "First task" }),
+      makeCard({ title: "Second task" }),
+    ];
+    render(<Column title="Backlog" cards={cards} />);
+    expect(screen.getByText("First task")).toBeInTheDocument();
+    expect(screen.getByText("Second task")).toBeInTheDocument();
+  });
+
+  it("has a scrollable card area", () => {
+    render(<Column title="Backlog" cards={[]} />);
+    const emptyMsg = screen.getByText("No cards");
+    const scrollContainer = emptyMsg.parentElement!;
+    expect(scrollContainer.className).toContain("overflow-y-auto");
+  });
+});


### PR DESCRIPTION
## Summary
- Create `Board.tsx` component that renders 5 columns (Backlog, To Do, In Progress, Review, Done) in a horizontal flex layout from `constants/columns.ts`
- Create `Column.tsx` component with header (title + card count badge), scrollable card area, and empty state message
- Wire up `useBoardState` in `App.tsx` and pass `getColumnCards` down to Board → Column

## Acceptance Criteria
- [x] All 5 columns render side by side with correct titles
- [x] Columns fill the viewport width equally (`flex-1`)
- [x] Each column shows its card count in the header
- [x] Card area is scrollable when content overflows (`overflow-y-auto`)
- [x] Layout is rendered from column config in `constants/columns.ts`
- [x] Component renders with no cards initially (empty state message per column)

## Test plan
- Board renders all 5 column titles
- Board renders columns in a flex row
- Board passes cards from getColumnCards to each column
- Board shows empty state in all columns with no cards
- Column renders title, card count badge, and empty state message
- Column card area has overflow-y-auto for scrolling
- App renders heading and all 5 columns
- All 25 tests pass

Closes #4