### PR TITLE
fix: integrate AddCardForm into Column/Board (#19)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { Board } from './components/Board';
 import { useBoardState } from './hooks/useBoardState';
 
 function App() {
-  const { getColumnCards, deleteCard, moveCard } = useBoardState();
+  const { getColumnCards, addCard, deleteCard, moveCard } = useBoardState();
 
   return (
     <div className="h-screen flex flex-col bg-gray-50">
@@ -12,7 +12,7 @@ function App() {
         </h1>
       </header>
       <main className="flex-1 overflow-hidden">
-        <Board getColumnCards={getColumnCards} onDeleteCard={deleteCard} onMoveCard={moveCard} />
+        <Board getColumnCards={getColumnCards} onAddCard={addCard} onDeleteCard={deleteCard} onMoveCard={moveCard} />
       </main>
     </div>
   );

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -17,11 +17,12 @@ import { Card } from './Card';
 
 interface BoardProps {
   getColumnCards: (columnId: ColumnId) => CardType[];
+  onAddCard: (columnId: ColumnId, title: string, description: string) => void;
   onDeleteCard: (cardId: string) => void;
   onMoveCard: (cardId: string, targetColumnId: ColumnId, targetPosition: number) => void;
 }
 
-export function Board({ getColumnCards, onDeleteCard, onMoveCard }: BoardProps) {
+export function Board({ getColumnCards, onAddCard, onDeleteCard, onMoveCard }: BoardProps) {
   const [activeCard, setActiveCard] = useState<CardType | null>(null);
   const [overColumnId, setOverColumnId] = useState<ColumnId | null>(null);
 
@@ -117,6 +118,7 @@ export function Board({ getColumnCards, onDeleteCard, onMoveCard }: BoardProps) 
             columnId={col.id}
             title={col.title}
             cards={getColumnCards(col.id)}
+            onAddCard={onAddCard}
             onDeleteCard={onDeleteCard}
             isOver={overColumnId === col.id}
           />

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -3,16 +3,18 @@ import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import type { Card as CardType } from '../types';
 import type { ColumnId } from '../types';
 import { Card } from './Card';
+import { AddCardForm } from './AddCardForm';
 
 interface ColumnProps {
   columnId: ColumnId;
   title: string;
   cards: CardType[];
+  onAddCard: (columnId: ColumnId, title: string, description: string) => void;
   onDeleteCard: (cardId: string) => void;
   isOver?: boolean;
 }
 
-export function Column({ columnId, title, cards, onDeleteCard, isOver }: ColumnProps) {
+export function Column({ columnId, title, cards, onAddCard, onDeleteCard, isOver }: ColumnProps) {
   const { setNodeRef } = useDroppable({ id: columnId });
 
   return (
@@ -33,6 +35,9 @@ export function Column({ columnId, title, cards, onDeleteCard, isOver }: ColumnP
             ))
           )}
         </SortableContext>
+      </div>
+      <div className="p-2 border-t border-gray-200">
+        <AddCardForm columnId={columnId} onAdd={onAddCard} />
       </div>
     </div>
   );

--- a/src/components/__tests__/Board.test.tsx
+++ b/src/components/__tests__/Board.test.tsx
@@ -8,7 +8,7 @@ describe('Board', () => {
   const noopMoveCard = vi.fn();
 
   it('renders all 5 column titles', () => {
-    render(<Board getColumnCards={emptyGetColumnCards} onDeleteCard={vi.fn()} onMoveCard={noopMoveCard} />);
+    render(<Board getColumnCards={emptyGetColumnCards} onAddCard={vi.fn()} onDeleteCard={vi.fn()} onMoveCard={noopMoveCard} />);
     expect(screen.getByText('Backlog')).toBeInTheDocument();
     expect(screen.getByText('To Do')).toBeInTheDocument();
     expect(screen.getByText('In Progress')).toBeInTheDocument();
@@ -18,7 +18,7 @@ describe('Board', () => {
 
   it('renders columns in a flex row', () => {
     const { container } = render(
-      <Board getColumnCards={emptyGetColumnCards} onDeleteCard={vi.fn()} onMoveCard={noopMoveCard} />,
+      <Board getColumnCards={emptyGetColumnCards} onAddCard={vi.fn()} onDeleteCard={vi.fn()} onMoveCard={noopMoveCard} />,
     );
     const boardEl = container.querySelector('.flex.gap-4');
     expect(boardEl).toBeInTheDocument();
@@ -45,6 +45,7 @@ describe('Board', () => {
     render(
       <Board
         getColumnCards={(colId: ColumnId) => mockCards[colId]}
+        onAddCard={vi.fn()}
         onDeleteCard={vi.fn()}
         onMoveCard={noopMoveCard}
       />,
@@ -55,7 +56,7 @@ describe('Board', () => {
 
   it('shows empty state in columns with no cards', () => {
     render(
-      <Board getColumnCards={emptyGetColumnCards} onDeleteCard={vi.fn()} onMoveCard={noopMoveCard} />,
+      <Board getColumnCards={emptyGetColumnCards} onAddCard={vi.fn()} onDeleteCard={vi.fn()} onMoveCard={noopMoveCard} />,
     );
     const emptyMessages = screen.getAllByText('No cards');
     expect(emptyMessages).toHaveLength(5);
@@ -64,8 +65,16 @@ describe('Board', () => {
   it('accepts onMoveCard prop', () => {
     const moveCard = vi.fn();
     render(
-      <Board getColumnCards={emptyGetColumnCards} onDeleteCard={vi.fn()} onMoveCard={moveCard} />,
+      <Board getColumnCards={emptyGetColumnCards} onAddCard={vi.fn()} onDeleteCard={vi.fn()} onMoveCard={moveCard} />,
     );
     expect(screen.getByText('Backlog')).toBeInTheDocument();
+  });
+
+  it('renders "+ Add Card" button in each column', () => {
+    render(
+      <Board getColumnCards={emptyGetColumnCards} onAddCard={vi.fn()} onDeleteCard={vi.fn()} onMoveCard={noopMoveCard} />,
+    );
+    const addButtons = screen.getAllByText('+ Add Card');
+    expect(addButtons).toHaveLength(5);
   });
 });

--- a/src/components/__tests__/Column.test.tsx
+++ b/src/components/__tests__/Column.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { DndContext } from '@dnd-kit/core';
 import { Column } from '../Column';
@@ -19,6 +19,7 @@ function renderColumn(props: Partial<Parameters<typeof Column>[0]> = {}) {
     columnId: 'backlog' as const,
     title: 'Backlog',
     cards: [] as Card[],
+    onAddCard: vi.fn(),
     onDeleteCard: vi.fn(),
     ...props,
   };
@@ -80,5 +81,26 @@ describe('Column', () => {
     const columnEl = container.firstElementChild!;
     expect(columnEl.className).not.toContain('bg-blue-100');
     expect(columnEl.className).toContain('bg-gray-100');
+  });
+
+  it('renders "+ Add Card" button', () => {
+    renderColumn();
+    expect(screen.getByText('+ Add Card')).toBeInTheDocument();
+  });
+
+  it('shows inline form when "+ Add Card" is clicked', () => {
+    renderColumn();
+    fireEvent.click(screen.getByText('+ Add Card'));
+    expect(screen.getByPlaceholderText('Card title')).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+
+  it('calls onAddCard when form is submitted with a title', () => {
+    const onAddCard = vi.fn();
+    renderColumn({ onAddCard });
+    fireEvent.click(screen.getByText('+ Add Card'));
+    fireEvent.change(screen.getByPlaceholderText('Card title'), { target: { value: 'New task' } });
+    fireEvent.click(screen.getByText('Add'));
+    expect(onAddCard).toHaveBeenCalledWith('backlog', 'New task', '');
   });
 });


### PR DESCRIPTION
## Summary
- Wire `addCard` from `useBoardState` through `App` → `Board` → `Column` → `AddCardForm`
- Each column now renders a "+ Add Card" button at the bottom
- Updated existing Board and Column tests for new `onAddCard` prop
- Added integration tests: form renders in columns, opens on click, calls callback on submit

## Test plan
- [x] All 55 existing tests pass
- [ ] Verify "+ Add Card" button appears at bottom of each column
- [ ] Click button → inline form opens with auto-focused title input
- [ ] Submit with title → card created at bottom of column, form closes
- [ ] Cancel or Escape → form closes without creating card
- [ ] Title required — empty submit is blocked

Closes #19